### PR TITLE
fix: use correct variable type for decoding bytes

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -16,7 +16,6 @@ package spannerdriver
 
 import (
 	"database/sql/driver"
-	"encoding/base64"
 	"io"
 	"log"
 	"sync"
@@ -115,19 +114,11 @@ func (r *rows) Next(dest []driver.Value) error {
 			dest[i] = v.StringVal
 		case sppb.TypeCode_BYTES:
 			// The column value is a base64 encoded string.
-			var v spanner.NullString
+			var v []byte
 			if err := col.Decode(&v); err != nil {
 				return err
 			}
-			if v.IsNull() {
-				dest[i] = []byte(nil)
-			} else {
-				b, err := base64.StdEncoding.DecodeString(v.StringVal)
-				if err != nil {
-					return err
-				}
-				dest[i] = b
-			}
+			dest[i] = v
 		case sppb.TypeCode_BOOL:
 			var v spanner.NullBool
 			if err := col.Decode(&v); err != nil {


### PR DESCRIPTION
The driver row iterator throws the following error when there is a `BYTES` value:
```
spanner: code = "InvalidArgument", desc = "type *spanner.NullString cannot be used for decoding BYTES"
```

This is due to the[ `decodeValue` function](https://github.com/googleapis/google-cloud-go/blob/b951d8bd194b76da0a8bf2ce7cf85b546d2e051c/spanner/value.go#L569) only supporting using `spanner.NullString` with the `STRING` type. When decoding the `BYTES` type, the function expects a `[]byte` variable.

This PR removes the unneeded conversion from the driver and uses the expected `[]bytes` variable instead.